### PR TITLE
Enable Link-Time Optimization (LTO)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ default = ["zlib-ng-compat"]
 zlib-ng-compat = ["git2/zlib-ng-compat"]
 
 [profile.release]
+lto = true
 strip = true
 
 [package.metadata.deb]


### PR DESCRIPTION
Hi!

I noticed that in the `Cargo.toml` file Link-Time Optimization (LTO) for the project is not enabled. I suggest switching it on since it will reduce the binary size (which is always a good thing to have).

I have made quick tests (Fedora 41, Rustc 1.83) by adding `lto = true` to the Release profile. The binary size reduction is from 5.4 Mib to 4.7 Mib.

Thank you.